### PR TITLE
fix: correctly resolve dependency ranges

### DIFF
--- a/analyzer/analyzer.ts
+++ b/analyzer/analyzer.ts
@@ -7,6 +7,7 @@ import { getDependencyMap } from "../utils/getDependencyMap.ts";
 import { diveFile } from "./diveFile.ts";
 import { getEntry } from "./getEntry.ts";
 import { getSpinner } from "./spinner.ts";
+import { resolveDependencyMap } from "../utils/resolveDependencyMap.ts";
 
 export async function analyze(d: string, v?: string, isJspm?: boolean, ghUser?: string): Promise<RegistryEntryV1> {
   const jsdelivrSrc = !!ghUser ? `${jsdelivr("gh")}/${ghUser}` : jsdelivr("npm");
@@ -27,7 +28,8 @@ export async function analyze(d: string, v?: string, isJspm?: boolean, ghUser?: 
     R.update({ version: pj.version!, description: pj.description ?? "" });
   }
 
-  const depMap = getDependencyMap(pj);
+  const rawDepMap = getDependencyMap(pj);
+  const depMap = await resolveDependencyMap(rawDepMap);
 
   const { entry, typesEntry } = getEntry(pj, R);
   R.update({ entry, typesEntry });

--- a/analyzer/determineFullModuleName.ts
+++ b/analyzer/determineFullModuleName.ts
@@ -19,7 +19,7 @@ export function determineFullModuleName(depMap: Record<string, string>, sourceVa
   const depName = `${fullName}@${depMap[fullName!]}`;
 
   if (!keys.includes(depName))
-    throw new Error(`${sourceValue} is not available in the registry yet, try adding that dependency first`);
+    throw new Error(`${depName} is not available in the registry yet, try adding that dependency first`);
 
   return `/package/${depName}`;
 }

--- a/utils/getDependencyMap.ts
+++ b/utils/getDependencyMap.ts
@@ -7,13 +7,13 @@ export function getDependencyMap(pj: PackageJson): Record<string, string> {
 
   for (const dep in deps) {
     const v = deps[dep];
-    depMap[dep] = v.startsWith("~") || v.startsWith("^") ? v.substr(1) : v;
+    depMap[dep] = v;
   }
 
   for (const dep in devDeps) {
     if (!depMap[dep]) {
       const v = devDeps[dep];
-      depMap[dep] = v.startsWith("~") || v.startsWith("^") ? v.substr(1) : v;
+      depMap[dep] = v;
     }
   }
 

--- a/utils/resolveDependencyMap.ts
+++ b/utils/resolveDependencyMap.ts
@@ -1,0 +1,30 @@
+import { path } from "./deps.ts";
+import { jsdelivr } from "./constants.ts";
+import { fetchPj } from "./fetchPj.ts";
+
+const VERSION_REGEXP = /^\d+.\d+.\d+$/;
+
+export async function resolveDependencyMap(
+  raw: Record<string, string>,
+): Promise<Record<string, string>> {
+  const jsdelivrSrc = jsdelivr("npm");
+  const final: Record<string, string> = {};
+
+  for (const name in raw) {
+    const version = raw[name];
+    if (VERSION_REGEXP.test(version)) {
+      final[name] = version;
+    }
+    const [_, pj] = await fetchPj(
+      path.join(jsdelivrSrc, `${name}${version ? `@${version}` : ""}`),
+    );
+    if (!pj.version) {
+      throw new Error(
+        `${name} @ ${version} is missing version in resolved package.json`,
+      );
+    }
+    final[name] = pj.version;
+  }
+
+  return final;
+}


### PR DESCRIPTION
I want to get `preact` and `preact-router` on dreg, and this is one of the prerequisites to get that working. In a different PR, I am also going to try to add support for the `exports` keyword in package.json (as this is needed for preact - see https://cdn.jsdelivr.net/npm/preact@10.5.2/package.json).
